### PR TITLE
JAVA-1427: DseGSSAPIAuthProvider should provide constructor for existing Subject

### DIFF
--- a/dse-driver/src/test/java/com/datastax/driver/dse/auth/DseGSSAPIAuthProviderTest.java
+++ b/dse-driver/src/test/java/com/datastax/driver/dse/auth/DseGSSAPIAuthProviderTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -97,6 +98,23 @@ public class DseGSSAPIAuthProviderTest extends CCMDseTestsSupport {
         return configureCCM()
                 .withDSEConfiguration("kerberos_options.keytab", alternateKeytab.getAbsolutePath())
                 .withDSEConfiguration("kerberos_options.service_principal", alternateServicePrincipal);
+    }
+
+
+    /**
+     * Ensures that a Cluster can be established to a DSE server secured with Kerberos and that simple queries can
+     * be made using a Subject from a previously established LoginContext.
+     *
+     * @test_category dse:authentication
+     */
+    @Test(groups = "long")
+    public void should_authenticate_using_subject() throws Exception {
+        String protocol = "dse";
+        Configuration configuration = keytabClient(userKeytab, userPrincipal);
+        LoginContext login = new LoginContext("DseClient", null, null, configuration);
+        login.login();
+        AuthProvider auth = new DseGSSAPIAuthProvider(login.getSubject());
+        connectAndQuery(auth);
     }
 
     /**


### PR DESCRIPTION
The DseGSSAPIAuthProvider in the dse-java-driver does not currently allow an application to provide an existing Subject.

In applications that communicate with various services requiring a kerberos ticket, it is preferable to have a single service principal for say hdfs and dse.

In this case it should not be necessary to manage multiple tickets and renewals and the auth provider should accept an existing subject.