### PR TITLE
JAVA-1266 & JAVA-1411: Stop using oss-parent and normalize versions across the build

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -9,9 +9,9 @@ platform: x64
 install:
   - ps: .\ci\appveyor.ps1
 build_script:
-  - "set \"JAVA_HOME=%JAVA_8_HOME%\" && mvn install -DskipTests=true -D\"maven.javadoc.skip\"=true -B -V"
+  - "set \"JAVA_HOME=%JAVA_8_HOME%\" && mvn install -DskipTests=true -B -V"
 test_script:
-  - "set \"JAVA_HOME=%JAVA_PLATFORM_HOME%\" && mvn -B -D\"ccm.java.home\"=\"%JAVA_8_HOME%\" -D\"ccm.maxNumberOfNodes\"=1 -D\"cassandra.version\"=%cassandra_version% test -P %test_profile%"
+  - "set \"JAVA_HOME=%JAVA_PLATFORM_HOME%\" && mvn -B -D\"ccm.java.home\"=\"%JAVA_8_HOME%\" -D\"ccm.maxNumberOfNodes\"=1 -D\"cassandra.version\"=%cassandra_version% verify -P %test_profile%"
 on_finish:
   - ps: .\ci\uploadtests.ps1
 cache:

--- a/docs.yaml
+++ b/docs.yaml
@@ -33,7 +33,7 @@ sections:
         files: 'faq/**/*.md'
 links:
   - title: Code
-    href:  https://github.com/datastax/java-driver-dse/
+    href:  https://github.com/datastax/java-dse-driver/
   - title: Docs
     href:  http://docs.datastax.com/en/developer/java-driver-dse
   - title: Issues

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -7,14 +7,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dse-java-driver-core</artifactId>
-    <packaging>bundle</packaging>
     <name>DataStax Enterprise Java Driver - Core</name>
     <description>
         A driver for DataStax Enterprise (DSE)
@@ -22,54 +24,47 @@
         Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol,
         supporting DSE-specific features such as geospatial types, DSE Graph and DSE authentication.
     </description>
-    <url>https://github.com/datastax/java-driver-dse</url>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-        <apacheds.version>2.0.0-M19</apacheds.version>
-    </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-ffi</artifactId>
-            <version>${jnr-ffi.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
-            <version>${jnr-posix.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
-            <version>${esri.version}</version>
         </dependency>
 
         <!-- Compression libraries for the protocol. -->
@@ -78,14 +73,12 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>${snappy.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>net.jpountz.lz4</groupId>
             <artifactId>lz4</artifactId>
-            <version>${lz4.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -94,62 +87,48 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${netty.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
-            <version>${hdr.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scassandra</groupId>
             <artifactId>java-client</artifactId>
-            <version>${scassandra.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>2.0.1.Final</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>
@@ -157,56 +136,48 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-core</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-protocol-kerberos</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-interceptor-kerberos</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-protocol-ldap</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-ldif-partition</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-jdbm-partition</artifactId>
-            <version>${apacheds.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,65 +204,85 @@
     </dependencies>
 
     <build>
+
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
         </resources>
+
         <plugins>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>test-jar</id>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
-                        <phase>test-compile</phase>
                     </execution>
                 </executions>
             </plugin>
+
+            <!--
+            We avoid packaging bundle because it does not play nicely with the shade plugin, see
+            https://stackoverflow.com/questions/31262032/maven-shade-plugin-and-custom-packaging-type
+            -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <!--
-                  Default configuration, used by the `bundle` goal that is implicitly bound to the `package` phase
-                  (because the project uses the `bundle` packaging)
-                  This generates the manifest for the 'shade-excluding-netty' artifact.
-                -->
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.core</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
-                        <Import-Package>
-                            <!-- JNR does not provide OSGi bundles, so exclude it; the driver can live without it -->
-                            <![CDATA[
-                                com.google.common.*;version="[16.0.1,22)",
-                                !jnr.*,
-                                !com.fasterxml.jackson.*,
-                                !com.esri.core.geometry.*,
-                                !org.json.*,
-                                !org.codehaus.jackson.*,
-                                ,*
-                            ]]></Import-Package>
-                        <Private-Package>com.datastax.shaded.*</Private-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
+                    <!--
+                    Prevent customized manifest entries from the project's maven-jar-plugin configuration from being read, see
+                    http://apache-felix.18485.x6.nabble.com/how-lt-manifestLocation-gt-is-used-in-maven-bundle-plugin-td4835566.html
+                    -->
+                    <archive>
+                        <forced>true</forced>
+                    </archive>
                 </configuration>
                 <executions>
+                    <!--
+                      Default configuration, used by the `bundle` goal that is implicitly bound to the `package` phase
+                      (because the project uses the `bundle` packaging)
+                      This generates the manifest for the 'shade-excluding-netty' artifact.
+                    -->
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
+                            <instructions>
+                                <Import-Package>
+                                    <!-- JNR does not provide OSGi bundles, so exclude it; the driver can live without it -->
+                                    <![CDATA[
+                                    com.google.common.*;version="[16.0.1,22)",
+                                    !jnr.*,
+                                    !com.fasterxml.jackson.*,
+                                    !com.esri.core.geometry.*,
+                                    !org.json.*,
+                                    !org.codehaus.jackson.*,
+                                    ,*
+                                ]]></Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
                     <!-- Alternate execution to generate the manifest for the 'shade-including-netty' artifact -->
                     <execution>
                         <id>bundle-manifest-shaded</id>
-                        <phase>prepare-package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
@@ -320,9 +311,9 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
                 <executions>
                     <!-- Shade Jackson and ESRI, but not Netty. This is the default artifact. -->
                     <execution>
@@ -465,58 +456,19 @@
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
 
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-jar-plugin</artifactId>
-                                        <versionRange>[2.2,)</versionRange>
-                                        <goals>
-                                            <goal>test-jar</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
     </build>
 
     <profiles>
+
         <profile>
             <id>isolated</id>
-            <properties>
-                <env>default</env>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
                             <skip>false</skip>
                             <includes>
@@ -532,30 +484,8 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
-
-    <licenses>
-        <license>
-            <name>DataStax DSE Driver License</name>
-            <url>http://www.datastax.com/terms/datastax-dse-driver-license-terms</url>
-            <distribution>repo</distribution>
-            <comments />
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver-dse.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver-dse.git</developerConnection>
-        <url>https://github.com/datastax/java-driver-dse</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 
 </project>
 

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -7,89 +7,53 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dse-java-driver-dist</artifactId>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-
     <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->
     <packaging>jar</packaging>
-
     <name>DataStax Enterprise Java Driver - Binary distribution</name>
 
     <!-- These dependencies are only here to ensure proper build order and proper inclusion of binaries in the final tarball -->
     <dependencies>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-graph</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+
     </dependencies>
 
     <build>
+
         <finalName>dse-java-driver-${project.version}</finalName>
+
         <plugins>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>dependencies-javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>assemble-binary-tarball</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <descriptors>
-                        <descriptor>src/assembly/binary-tarball.xml</descriptor>
-                    </descriptors>
-                    <tarLongFileMode>posix</tarLongFileMode>
-                </configuration>
-            </plugin>
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <!-- http://stackoverflow.com/questions/13218313/unable-to-disable-generation-of-empty-jar-maven-jar-plugin -->
                 <executions>
                     <execution>
@@ -98,24 +62,84 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>dependencies-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <includeDependencySources>true</includeDependencySources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>assemble-binary-tarball</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/assembly/binary-tarball.xml</descriptor>
+                            </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>
 

--- a/driver-dist/src/assembly/binary-tarball.xml
+++ b/driver-dist/src/assembly/binary-tarball.xml
@@ -63,6 +63,9 @@
                             <exclude>com.datastax.dse:dse-java-driver-mapping</exclude>
                             <exclude>com.datastax.dse:dse-java-driver-extras</exclude>
                             <exclude>com.datastax.dse:dse-java-driver-graph</exclude>
+                            <!-- already included in lib/core -->
+                            <exclude>com.google.guava:guava</exclude>
+                            <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>
@@ -89,6 +92,7 @@
                             <exclude>com.datastax.dse:dse-java-driver-graph</exclude>
                             <!-- already included in lib/core -->
                             <exclude>com.google.guava:guava</exclude>
+                            <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>
@@ -113,6 +117,9 @@
                             <exclude>com.datastax.dse:dse-java-driver-mapping</exclude>
                             <exclude>com.datastax.dse:dse-java-driver-extras</exclude>
                             <exclude>com.datastax.dse:dse-java-driver-graph</exclude>
+                            <!-- already included in lib/core -->
+                            <exclude>com.google.guava:guava</exclude>
+                            <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -6,27 +6,19 @@
          http://www.datastax.com/terms/datastax-dse-driver-license-terms
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dse-java-driver-examples</artifactId>
-
     <name>DataStax Enterprise Java Driver - Examples</name>
     <description>A collection of examples to demonstrate DataStax Enterprise Java Driver.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-        <jax-rs.version>2.0.1</jax-rs.version>
-        <jersey.version>2.23.1</jersey.version>
-        <hk2.version>2.4.0-b34</hk2.version>
-        <logback.version>1.1.3</logback.version>
-    </properties>
 
     <dependencies>
 
@@ -35,19 +27,18 @@
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-graph</artifactId>
-            <version>${project.parent.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <!--Jackson-->
@@ -55,14 +46,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -71,14 +60,12 @@
         <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
-            <version>${jsr353-api.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>${jsr353-ri.version}</version>
             <optional>true</optional>
             <scope>runtime</scope>
         </dependency>
@@ -88,7 +75,6 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>${jax-rs.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -97,31 +83,40 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jdk-http</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
-
 
         <!--CDI frameworks (HK2)-->
 
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>${hk2.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Standard annotations -->
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -130,7 +125,14 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+        </dependency>
+
+        <!-- Tinkerpop -->
+
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-groovy</artifactId>
+            <optional>true</optional>
         </dependency>
 
     </dependencies>
@@ -142,7 +144,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -151,25 +152,34 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -178,5 +188,24 @@
         </plugins>
 
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -6,64 +6,60 @@
          http://www.datastax.com/terms/datastax-dse-driver-license-terms
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dse-java-driver-extras</artifactId>
     <packaging>bundle</packaging>
     <name>DataStax Enterprise Java Driver - Extras</name>
     <description>Extended functionality for the DataStax Enterprise Java driver.</description>
-    <url>https://github.com/datastax/java-driver-dse</url>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-        <test.groups>unit</test.groups>
-    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>${joda.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
-            <version>${jsr353-api.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -71,56 +67,48 @@
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>${jsr353-ri.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -133,57 +121,16 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.extras</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
                         <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
                 </configuration>
             </plugin>
 
         </plugins>
 
     </build>
-
-    <licenses>
-        <license>
-            <name>DataStax DSE Driver License</name>
-            <url>http://www.datastax.com/terms/datastax-dse-driver-license-terms</url>
-            <distribution>repo</distribution>
-            <comments />
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver-dse.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver-dse.git</developerConnection>
-        <url>https://github.com/datastax/java-driver-dse</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 
 </project>

--- a/driver-graph/pom.xml
+++ b/driver-graph/pom.xml
@@ -6,21 +6,23 @@
          http://www.datastax.com/terms/datastax-dse-driver-license-terms
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dse-java-driver-graph</artifactId>
     <packaging>bundle</packaging>
-    <name>DataStax Enterprise Java Driver - Graph API</name>
+    <name>DataStax Enterprise Java Driver - Graph</name>
     <description>An implementation of the Apache TinkerPop graph computing framework for DSE Graph.</description>
 
     <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>
@@ -28,39 +30,43 @@
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-shaded</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy</artifactId>
-            <version>${tinkerpop.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>tinkergraph-gremlin</artifactId>
-            <version>${tinkerpop.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -68,14 +74,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -86,64 +90,32 @@
         <plugins>
 
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <optimize>true</optimize>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
                 <executions>
+                    <!-- this submodule compiles entirely against JDK 8 only -->
                     <execution>
-                        <id>check</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
+                        <id>check-jdk6</id>
                         <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java18</artifactId>
-                                <version>1.0</version>
-                            </signature>
+                            <skip>true</skip>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.graph</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
                         <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
 
     <profiles>
@@ -156,10 +128,11 @@
             <build>
                 <plugins>
                     <plugin>
-                        <!-- do not execute tests in this module
-                         if tests are ran with JDK6 or 7 as this module requires JDK 8. -->
+                        <!--
+                        Do not execute tests in this module
+                        if tests are ran with JDK6 or 7 as this module requires JDK 8.
+                        -->
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -7,114 +7,101 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dse-java-driver-mapping</artifactId>
     <packaging>bundle</packaging>
     <name>DataStax Enterprise Java Driver - Object Mapping</name>
     <description>Object mapper for the DataStax Enterprise Java Driver.</description>
-    <url>https://github.com/datastax/java-driver-dse</url>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-        <groovy.version>2.4.7</groovy.version>
-    </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.dse</groupId>
-            <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.datastax.dse</groupId>
+            <artifactId>dse-java-driver-core</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.3</version>
+            <artifactId>asm</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--
-        <dependency>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-          <version>4.1</version>
-        </dependency>
-        <dependency>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-util</artifactId>
-          <version>4.1</version>
-        </dependency>
-      -->
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
 
     <build>
+
         <plugins>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.12</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -130,88 +117,25 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.mapping</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
                         <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
-                <version>1.5</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <fileset>
-                                    <directory>${pom.basedir}/src/test/groovy</directory>
-                                    <includes>
-                                        <include>**/*.groovy</include>
-                                    </includes>
-                                </fileset>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>${groovy.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
+
         </plugins>
+
     </build>
 
-    <licenses>
-        <license>
-            <name>DataStax DSE Driver License</name>
-            <url>http://www.datastax.com/terms/datastax-dse-driver-license-terms</url>
-            <distribution>repo</distribution>
-            <comments />
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver-dse.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver-dse.git</developerConnection>
-        <url>https://github.com/datastax/java-driver-dse</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 </project>
-

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -7,7 +7,9 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-tests-parent</artifactId>
@@ -15,65 +17,59 @@
     </parent>
 
     <artifactId>dse-java-driver-tests-osgi</artifactId>
-    <packaging>jar</packaging>
     <name>DataStax Enterprise Java Driver Tests - OSGi</name>
     <description>A test for the DataStax Java Driver in an OSGi container.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <felix.version>4.4.1</felix.version>
-        <!-- more recent version require JDK7+ -->
-        <pax-exam.version>3.6.0</pax-exam.version>
-        <url.version>2.4.0</url.version>
-        <logback.version>1.1.3</logback.version>
-        <slf4j.version>1.7.5</slf4j.version>
-        <test.groups>none</test.groups>
-        <!--
-        Skip tests by default, short or long profile is required to run tests in this module
-        since pax-exam will throw exception if it encounters a
-        test with no matching methods.
-        -->
-        <test.skip>true</test.skip>
-        <main.basedir>${project.parent.parent.basedir}</main.basedir>
-    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-posix</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>${felix.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -81,78 +77,60 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-testng</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-forked</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-reference</artifactId>
-            <version>${url.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -167,25 +145,16 @@
             get automatically passed to tests run with IntelliJ
             -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
                     <skip>true</skip>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
-                    <skip>${test.skip}</skip>
-                    <groups>${test.groups}</groups>
+                    <skip>${test.osgi.skip}</skip>
                     <systemPropertyVariables>
                         <cassandra.version>${cassandra.version}</cassandra.version>
                         <!-- pull in declared version properties, this ensures we test with the same versions used by the driver -->
@@ -198,29 +167,18 @@
                         <logback.version>${logback.version}</logback.version>
                         <metrics.version>${metrics.version}</metrics.version>
                         <testng.version>${testng.version}</testng.version>
+                        <jsr353-api.version>${jsr353-api.version}</jsr353-api.version>
                         <ipprefix>${ipprefix}</ipprefix>
                     </systemPropertyVariables>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.osgi</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>com.datastax.driver.osgi.api,!com.datastax.driver.osgi.impl</Export-Package>
                         <Bundle-Activator>com.datastax.driver.osgi.impl.Activator</Bundle-Activator>
                         <_include>-osgi.bnd</_include>
@@ -229,7 +187,7 @@
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
@@ -237,50 +195,9 @@
                 </executions>
             </plugin>
 
-            <!--
-            To launch Pax Runner and check that all driver bundles are correctly provisioned,
-            do the following:
-            mvn pax:run
-            Note: you MUST run 'mvn install' on the entire project before!
-             -->
-            <plugin>
-                <groupId>org.ops4j</groupId>
-                <artifactId>maven-pax-plugin</artifactId>
-                <version>1.6.0</version>
-                <configuration>
-                    <framework>felix</framework>
-                    <showWarnings>true</showWarnings>
-                    <provision>
-                        <param>--platform=felix</param>
-                        <param>--version=${felix.version}</param>
-                        <param>--log=debug</param>
-                        <param>--systemPackages=sun.misc</param>
-                    </provision>
-                </configuration>
-            </plugin>
-
         </plugins>
 
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>short</id>
-            <properties>
-                <test.groups>unit,short</test.groups>
-                <test.skip>false</test.skip>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>long</id>
-            <properties>
-                <test.groups>unit,short,long</test.groups>
-                <test.skip>false</test.skip>
-            </properties>
-        </profile>
-
-    </profiles>
 </project>
 

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -21,6 +21,18 @@ import java.util.List;
 
 import static org.ops4j.pax.exam.CoreOptions.*;
 
+/**
+ * To check that all driver bundles are correctly provisioned, or to debug provisioning problems,
+ * run the Maven Pax Runner plugin:
+ * <pre>
+ * mvn pax:run
+ * </pre>
+ * The plugin will start a Felix Gogo interactive shell and attempt to provision the driver bundles.
+ * <p/>
+ * Note: you MUST run 'mvn install' on the entire project before!
+ *
+ * @see <a href="http://felix.apache.org/documentation/subprojects/apache-felix-gogo.html">Apache Felix Gogo Documentation</a>
+ */
 public class BundleOptions {
 
     public static UrlProvisionOption driverBundle() {

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -7,21 +7,19 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dse-java-driver-tests-parent</artifactId>
     <packaging>pom</packaging>
     <name>DataStax Enterprise Java Driver Tests</name>
     <description>Tests for the DataStax Enterprise Java Driver.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
 
     <modules>
         <module>stress</module>
@@ -35,25 +33,41 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -62,5 +76,24 @@
         </plugins>
 
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -7,27 +7,29 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.dse</groupId>
         <artifactId>dse-java-driver-tests-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dse-java-driver-tests-stress</artifactId>
-    <packaging>jar</packaging>
     <name>DataStax Enterprise Java Driver Tests - Stress</name>
     <description>A stress test example for DataStax Enterprise Java Driver.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <main.basedir>${project.parent.parent.basedir}</main.basedir>
-    </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>com.datastax.dse</groupId>
             <artifactId>dse-java-driver-core</artifactId>
-            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>
@@ -45,21 +47,21 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
         </dependency>
+
     </dependencies>
 
     <build>
+
         <plugins>
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -71,7 +73,10 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
+
 </project>
 

--- a/manual/README.md
+++ b/manual/README.md
@@ -277,7 +277,7 @@ for (ColumnDefinitions.Definition definition : row.getColumnDefinitions()) {
 If you're reading this from the [generated HTML documentation on
 datastax.com](http://docs.datastax.com/en/developer/java-driver-dse/1.1/), use the "Contents"
 menu on the right hand side to navigate sub-sections. If you're [browsing the source files on
-github.com](https://github.com/datastax/java-driver-dse/tree/1.x/manual),
+github.com](https://github.com/datastax/java-dse-driver/tree/1.x/manual),
 simply navigate to each sub-directory.
 
 [DseCluster]:               http://docs.datastax.com/en/drivers/java-dse/1.2/com/datastax/driver/dse/DseCluster.html

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,8 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-        <relativePath />
-    </parent>
 
     <groupId>com.datastax.dse</groupId>
     <artifactId>dse-java-driver-parent</artifactId>
@@ -27,134 +22,975 @@
         supporting DSE-specific features such as geospatial types, DSE Graph and DSE authentication.
     </description>
 
-    <url>https://github.com/datastax/java-driver-dse</url>
+    <url>https://github.com/${github_org}/java-dse-driver</url>
     <inceptionYear>2012</inceptionYear>
 
     <modules>
         <module>driver-core</module>
         <module>driver-mapping</module>
         <module>driver-extras</module>
+        <module>driver-graph</module>
         <module>driver-examples</module>
         <module>driver-tests</module>
-        <module>driver-graph</module>
         <module>driver-dist</module>
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <github_org>datastax</github_org>
         <cassandra.version>5.1.0</cassandra.version>
         <dse>true</dse>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
-        <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
         <netty.version>4.0.47.Final</netty.version>
         <metrics.version>3.2.2</metrics.version>
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.3.0</lz4.version>
         <hdr.version>2.1.9</hdr.version>
-        <esri.version>1.2.1</esri.version>
-        <!-- driver-extras module -->
         <jackson.version>2.6.3</jackson.version>
+        <jackson-databind.version>2.6.3</jackson-databind.version>
+        <esri.version>1.2.1</esri.version>
         <joda.version>2.9.1</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <jnr-ffi.version>2.0.7</jnr-ffi.version>
         <jnr-posix.version>3.0.27</jnr-posix.version>
-        <!-- java-dse-graph module -->
+        <groovy.version>2.4.7</groovy.version>
+        <jax-rs.version>2.0.1</jax-rs.version>
+        <jersey.version>2.23.1</jersey.version>
+        <hk2.version>2.4.0-b34</hk2.version>
+        <felix.version>4.4.1</felix.version>
+        <!-- more recent versions of pax-exam require JDK7+ -->
+        <pax-exam.version>3.6.0</pax-exam.version>
+        <url.version>2.4.0</url.version>
         <tinkerpop.version>3.2.4</tinkerpop.version>
-
-        <!-- test dependency versions -->
+        <apacheds.version>2.0.0-M19</apacheds.version>
+        <groovy.version>2.4.7</groovy.version>
         <testng.version>6.8.8</testng.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.10.8</mockito.version>
         <commons-exec.version>1.3</commons-exec.version>
         <scassandra.version>1.1.2</scassandra.version>
-        <main.basedir>${project.basedir}</main.basedir>
+        <logback.version>1.2.3</logback.version>
         <byteman.version>3.0.8</byteman.version>
         <ipprefix>127.0.1.</ipprefix>
+        <!-- defaults below are overridden by profiles and/or submodules -->
         <test.groups>unit</test.groups>
-        <!-- Set default javadoc.opts, overriden by profiles -->
+        <test.osgi.skip>true</test.osgi.skip>
         <javadoc.opts />
-        <github_org>datastax</github_org>
     </properties>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <dependency>
+                <groupId>com.datastax.dse</groupId>
+                <artifactId>dse-java-driver-core</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.dse</groupId>
+                <artifactId>dse-java-driver-core</artifactId>
+                <version>${project.parent.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.dse</groupId>
+                <artifactId>dse-java-driver-mapping</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.dse</groupId>
+                <artifactId>dse-java-driver-extras</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.dse</groupId>
+                <artifactId>dse-java-driver-graph</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-ffi</artifactId>
+                <version>${jnr-ffi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-posix</artifactId>
+                <version>${jnr-posix.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.jpountz.lz4</groupId>
+                <artifactId>lz4</artifactId>
+                <version>${lz4.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${hdr.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.esri.geometry</groupId>
+                <artifactId>esri-geometry-api</artifactId>
+                <version>${esri.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>${jsr353-ri.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${jsr353-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${jax-rs.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-server</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-jdk-http</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>${hk2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>jta</artifactId>
+                <version>1.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tinkerpop</groupId>
+                <artifactId>gremlin-core</artifactId>
+                <version>${tinkerpop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tinkerpop</groupId>
+                <artifactId>gremlin-shaded</artifactId>
+                <version>${tinkerpop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tinkerpop</groupId>
+                <artifactId>gremlin-groovy</artifactId>
+                <version>${tinkerpop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tinkerpop</groupId>
+                <artifactId>tinkergraph-gremlin</artifactId>
+                <version>${tinkerpop.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.framework</artifactId>
+                <version>${felix.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-testng</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-container-forked</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-link-mvn</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.url</groupId>
+                <artifactId>pax-url-reference</artifactId>
+                <version>${url.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.scassandra</groupId>
+                <artifactId>java-client</artifactId>
+                <version>${scassandra.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-exec</artifactId>
+                <version>${commons-exec.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative</artifactId>
+                <version>2.0.1.Final</version>
+                <classifier>${os.detected.classifier}</classifier>
+            </dependency>
+
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-log4j12.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>5.0.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-core</artifactId>
+                <version>${apacheds.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-protocol-kerberos</artifactId>
+                <version>${apacheds.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-interceptor-kerberos</artifactId>
+                <version>${apacheds.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-protocol-ldap</artifactId>
+                <version>${apacheds.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-ldif-partition</artifactId>
+                <version>${apacheds.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-jdbm-partition</artifactId>
+                <version>${apacheds.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.api</groupId>
+                <artifactId>api-ldap-codec-standalone</artifactId>
+                <version>1.0.0-M26</version>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <build>
+
+        <extensions>
+
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.1.Final</version>
+            </extension>
+
+        </extensions>
+
+        <!--
+        Run the following command to check if plugin updates are available:
+        mvn versions:display-plugin-updates
+        -->
+        <pluginManagement>
+
+            <plugins>
+
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.6</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <!-- last version compatible with Java 6 -->
+                    <version>1.9.1</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.6.1</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <optimize>true</optimize>
+                        <showDeprecation>true</showDeprecation>
+                        <showWarnings>true</showWarnings>
+                        <!--
+                        Avoids warnings when cross-compiling to older source levels, see
+                        https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
+                        -->
+                        <compilerArgument>-Xlint:-options</compilerArgument>
+                        <!-- this actually means: use incremental compilation -->
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.gmaven</groupId>
+                    <artifactId>gmaven-plugin</artifactId>
+                    <version>1.5</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>testCompile</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <fileset>
+                                        <directory>${pom.basedir}/src/test/groovy</directory>
+                                        <includes>
+                                            <include>**/*.groovy</include>
+                                        </includes>
+                                    </fileset>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-all</artifactId>
+                            <version>${groovy.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <verbose>false</verbose>
+                        <additionalparam>${javadoc.opts}</additionalparam>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
+                            <link>http://netty.io/4.0/api/</link>
+                            <link>http://esri.github.io/geometry-api-java/javadoc/</link>
+                            <link>http://www.joda.org/joda-time/apidocs/</link>
+                            <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
+                            <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
+                            <link>https://javaee-spec.java.net/nonav/javadocs/</link>
+                        </links>
+                        <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>org.xerial.snappy</groupId>
+                                <artifactId>snappy-java</artifactId>
+                                <version>${snappy.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>net.jpountz.lz4</groupId>
+                                <artifactId>lz4</artifactId>
+                                <version>${lz4.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>org.hdrhistogram</groupId>
+                                <artifactId>HdrHistogram</artifactId>
+                                <version>${hdr.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-core</artifactId>
+                                <version>${jackson.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-annotations</artifactId>
+                                <version>${jackson.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-databind</artifactId>
+                                <version>${jackson-databind.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>joda-time</groupId>
+                                <artifactId>joda-time</artifactId>
+                                <version>${joda.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>javax.json</groupId>
+                                <artifactId>javax.json-api</artifactId>
+                                <version>${jsr353-api.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.esri.geometry</groupId>
+                                <artifactId>esri-geometry-api</artifactId>
+                                <version>${esri.version}</version>
+                            </additionalDependency>
+                        </additionalDependencies>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <extensions>true</extensions>
+                    <!-- last version compatible with Java 6 -->
+                    <version>2.5.4</version>
+                    <configuration>
+                        <instructions>
+                            <Bundle-Version>${project.version}</Bundle-Version>
+                            <_include>-osgi.bnd</_include>
+                        </instructions>
+                        <supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
+                            <supportedProjectType>pom</supportedProjectType>
+                        </supportedProjectTypes>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <configuration>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <releaseProfiles>release</releaseProfiles>
+                        <goals>deploy</goals>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>clirr-maven-plugin</artifactId>
+                    <!-- Last version compatible with Java 6 -->
+                    <version>2.7</version>
+                    <executions>
+                        <execution>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <comparisonVersion>1.2.4</comparisonVersion>
+                        <ignoredDifferencesFile>../clirr-ignores.xml</ignoredDifferencesFile>
+                        <excludes>
+                            <exclude>com/datastax/shaded/**</exclude>
+                        </excludes>
+                    </configuration>
+                    <!--
+                    Workaround to make clirr plugin work with Java 8.
+                    The bug is actually in the BCEL library,
+                    see https://issues.apache.org/jira/browse/BCEL-173.
+                    See also https://github.com/RichardWarburton/lambda-behave/issues/31#issuecomment-86052095
+                    -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.code.findbugs</groupId>
+                            <artifactId>bcel-findbugs</artifactId>
+                            <version>6.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>3.0</version>
+                    <configuration>
+                        <inlineHeader><![CDATA[
+
+Copyright (C) 2012-2017 DataStax Inc.
+
+This software can be used solely with DataStax Enterprise. Please consult the license at
+http://www.datastax.com/terms/datastax-dse-driver-license-terms
+
+]]>
+                        </inlineHeader>
+                        <includes>
+                            <include>src/**/*.java</include>
+                            <include>src/**/*.xml</include>
+                            <include>src/**/*.properties</include>
+                            <include>**/pom.xml</include>
+                        </includes>
+                        <mapping>
+                            <java>SLASHSTAR_STYLE</java>
+                            <properties>SCRIPT_STYLE</properties>
+                        </mapping>
+                        <strictCheck>true</strictCheck>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-license</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.15</version>
+                    <executions>
+                        <execution>
+                            <id>check-jdk6</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <signature>
+                                    <groupId>org.codehaus.mojo.signature</groupId>
+                                    <artifactId>java16</artifactId>
+                                    <version>1.0</version>
+                                </signature>
+                                <annotations>
+                                    <annotation>com.datastax.driver.dse.IgnoreJDK6Requirement</annotation>
+                                    <annotation>com.datastax.driver.extras.codecs.jdk8.IgnoreJDK6Requirement</annotation>
+                                </annotations>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>check-jdk8</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <signature>
+                                    <groupId>org.codehaus.mojo.signature</groupId>
+                                    <artifactId>java18</artifactId>
+                                    <version>1.0</version>
+                                </signature>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-1302 is fixed -->
+                    <version>2.18</version>
+                    <configuration>
+                        <groups>${test.groups}</groups>
+                        <useFile>false</useFile>
+                        <systemPropertyVariables>
+                            <cassandra.version>${cassandra.version}</cassandra.version>
+                            <ipprefix>${ipprefix}</ipprefix>
+                            <dse>${dse}</dse>
+                            <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
+                        </systemPropertyVariables>
+                        <classpathDependencyExcludes>
+                            <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+                        </classpathDependencyExcludes>
+                        <properties>
+                            <property>
+                                <name>usedefaultlisteners</name>
+                                <value>false
+                                </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                            </property>
+                            <property>
+                                <!-- Don't skip tests after a @Before method throws a SkipException -->
+                                <name>configfailurepolicy</name>
+                                <value>continue</value>
+                            </property>
+                        </properties>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <!-- do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-1302 is fixed -->
+                    <version>2.18</version>
+                    <configuration>
+                        <groups>${test.groups}</groups>
+                        <useFile>false</useFile>
+                        <systemPropertyVariables>
+                            <cassandra.version>${cassandra.version}</cassandra.version>
+                            <ipprefix>${ipprefix}</ipprefix>
+                            <dse>${dse}</dse>
+                            <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
+                        </systemPropertyVariables>
+                        <classpathDependencyExcludes>
+                            <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+                        </classpathDependencyExcludes>
+                        <properties>
+                            <property>
+                                <name>usedefaultlisteners</name>
+                                <value>false
+                                </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                            </property>
+                            <property>
+                                <!-- Don't skip tests after a @Before method throws a SkipException -->
+                                <name>configfailurepolicy</name>
+                                <value>continue</value>
+                            </property>
+                        </properties>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.5</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <extensions>true</extensions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.ops4j</groupId>
+                    <artifactId>maven-pax-plugin</artifactId>
+                    <version>1.6.0</version>
+                    <configuration>
+                        <framework>felix</framework>
+                        <showWarnings>true</showWarnings>
+                        <provision>
+                            <param>--platform=felix</param>
+                            <param>--version=${felix.version}</param>
+                            <param>--log=debug</param>
+                            <param>--systemPackages=sun.misc</param>
+                        </provision>
+                    </configuration>
+                </plugin>
+
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <artifactId>maven-jar-plugin</artifactId>
+                                        <versionRange>[2.2,)</versionRange>
+                                        <goals>
+                                            <goal>test-jar</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+
+            </plugins>
+
+        </pluginManagement>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>clirr-maven-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+
+    </build>
 
     <profiles>
 
         <profile>
-            <id>default</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit</test.groups>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-
-        <profile>
-            <id>doclint-java8-disable</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <javadoc.opts>-Xdoclint:none</javadoc.opts>
-            </properties>
-        </profile>
-
-        <profile>
             <id>short</id>
             <properties>
-                <env>default</env>
                 <test.groups>unit,short</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
             </properties>
         </profile>
 
         <profile>
             <id>long</id>
             <properties>
-                <env>default</env>
                 <test.groups>unit,short,long</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
             </properties>
         </profile>
 
         <profile>
             <id>duration</id>
             <properties>
-                <env>default</env>
                 <test.groups>unit,short,long,duration</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
             </properties>
         </profile>
 
         <profile>
             <id>doc</id>
             <properties>
-                <env>default</env>
                 <test.groups>unit,doc</test.groups>
             </properties>
         </profile>
 
+        <!-- default profile settings for 'isolated' test group, will skip tests unless overridden in child module. -->
         <profile>
-            <!-- default profile settings for 'isolated' test group, will skip tests unless overridden in child module. -->
             <id>isolated</id>
             <properties>
-                <env>default</env>
                 <test.groups>isolated</test.groups>
             </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
-                            <properties>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false
-                                    </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
-                                </property>
-                            </properties>
                             <skip>true</skip>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
@@ -162,22 +998,23 @@
                             <!-- This requires includes to be explicitly specified by implementing classes.
                                  This is needed to prevent creating a JVM fork for each test, even those that don't
                                  have the isolated group. -->
-                            <includes />
+                            <includes/>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
 
-        <!-- Used during releases to enforce compilation with JDK 8 -->
+        <!--
+        Profile activated when releasing. See:
+        http://central.sonatype.org/pages/apache-maven.html
+        -->
         <profile>
-            <id>enforce-java8</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>1.4.1</version>
                         <executions>
                             <execution>
                                 <id>enforce-java8</id>
@@ -194,18 +1031,65 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <skipLocalStaging>true</skipLocalStaging>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
 
-        <!--
-        This profile excludes all JDK 8 dependent tests from being
-        run with legacy JDKs (6 or 7).
-        It is automatically activated when a legacy JDK is in use.
-        Note that running tests with a legacy JDK require
-        that you provide a non-legacy JDK for CCM through the
-        system property ccm.java.home.
-        -->
+        <profile>
+            <id>modern-jdks</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+
         <profile>
             <id>legacy-jdks</id>
             <activation>
@@ -214,15 +1098,19 @@
             <build>
                 <plugins>
                     <plugin>
-                        <!-- exclude Jdk* test classes from being run
+                        <!--
+                        Exclude Jdk* test classes from being run
                         This is needed in event that code was built with JDK8
-                        and tests are ran with JDK6 or 7. -->
+                        and tests are ran with JDK6 or 7.
+                        Note that running CCM tests with a legacy JDK require
+                        setting two system properties: ccm.java.home and ccm.path;
+                        both should point to a valid JDK8+ installation.
+                        -->
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
                             <excludes>
-                                <exclude>**/Jdk8*.java</exclude>
                                 <exclude>**/jdk8/*.java</exclude>
+                                <exclude>**/Jdk8*.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -232,299 +1120,12 @@
 
     </profiles>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <optimize>true</optimize>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <!--
-                    Avoids warnings when cross-compiling to older source levels, see
-                    https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
-                    -->
-                    <compilerArgument>-Xlint:-options</compilerArgument>
-                    <!-- this actually means: use incremental compilation -->
-                    <useIncrementalCompilation>false</useIncrementalCompilation>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <inherited>true</inherited>
-                <configuration>
-                    <quiet>true</quiet>
-                    <verbose>false</verbose>
-                    <additionalparam>${javadoc.opts}</additionalparam>
-                    <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
-                        <link>http://netty.io/4.0/api/</link>
-                        <link>http://esri.github.io/geometry-api-java/javadoc/</link>
-                        <!-- dependencies from driver-extras -->
-                        <link>http://www.joda.org/joda-time/apidocs/</link>
-                        <link>http://fasterxml.github.io/jackson-core/javadoc/2.6/</link>
-                        <link>http://fasterxml.github.io/jackson-databind/javadoc/2.6/</link>
-                        <link>https://javaee-spec.java.net/nonav/javadocs/</link>
-                        <link>https://tinkerpop.apache.org/javadocs/${tinkerpop.version}/full/</link>
-                    </links>
-                    <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>org.xerial.snappy</groupId>
-                            <artifactId>snappy-java</artifactId>
-                            <version>${snappy.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>net.jpountz.lz4</groupId>
-                            <artifactId>lz4</artifactId>
-                            <version>${lz4.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>org.hdrhistogram</groupId>
-                            <artifactId>HdrHistogram</artifactId>
-                            <version>${hdr.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-core</artifactId>
-                            <version>${jackson.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-annotations</artifactId>
-                            <version>${jackson.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-databind</artifactId>
-                            <version>${jackson.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>joda-time</groupId>
-                            <artifactId>joda-time</artifactId>
-                            <version>${joda.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>javax.json</groupId>
-                            <artifactId>javax.json-api</artifactId>
-                            <version>${jsr353-api.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.esri.geometry</groupId>
-                            <artifactId>esri-geometry-api</artifactId>
-                            <version>${esri.version}</version>
-                        </additionalDependency>
-                    </additionalDependencies>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <preparationGoals>clean verify -Penforce-java8</preparationGoals>
-                    <!-- do NOT specify arguments tag here as it would override the arguments tag in this plugin's definition in the parent POM -->
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <!-- last version that supports JDK6 -->
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <comparisonVersion>1.2.3</comparisonVersion>
-                    <includes>
-                        <include>com/datastax/driver/**</include>
-                        <include>com/datastax/dse/graph/api/**</include>
-                    </includes>
-                    <ignoredDifferencesFile>../clirr-ignores.xml</ignoredDifferencesFile>
-                </configuration>
-                <!--
-                Workaround to make clirr plugin work with Java 8.
-                The bug is actually in the BCEL library,
-                see https://issues.apache.org/jira/browse/BCEL-173.
-                See also https://github.com/RichardWarburton/lambda-behave/issues/31#issuecomment-86052095
-                -->
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>bcel-findbugs</artifactId>
-                        <version>6.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <!--
-            To update license headers run:
-            mvn license:format
-            -->
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <header>${main.basedir}/src/license/header.txt</header>
-                    <includes>
-                        <include>src/**/*.java</include>
-                        <include>src/**/*.xml</include>
-                        <include>src/**/*.properties</include>
-                        <include>**/pom.xml</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/src/main/config/ide/**</exclude>
-                    </excludes>
-                    <mapping>
-                        <java>SLASHSTAR_STYLE</java>
-                        <properties>SCRIPT_STYLE</properties>
-                    </mapping>
-                    <strictCheck>true</strictCheck>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check-license</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
-                <executions>
-                    <!-- First check: all classes must comply with JDK 6,
-                    except those annotated with @IgnoreJDK6Requirement -->
-                    <execution>
-                        <id>check</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java16</artifactId>
-                                <version>1.0</version>
-                            </signature>
-                            <!-- each module must declare its own annotation -->
-                            <annotations>
-                                <annotation>com.datastax.driver.dse.IgnoreJDK6Requirement</annotation>
-                                <annotation>com.datastax.driver.extras.codecs.jdk8.IgnoreJDK6Requirement</annotation>
-                            </annotations>
-                        </configuration>
-                    </execution>
-                    <!-- Second check: all classes must comply with JDK 8 -->
-                    <execution>
-                        <id>check-jdk8</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java18</artifactId>
-                                <version>1.0</version>
-                            </signature>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <groups>${test.groups}</groups>
-                    <useFile>false</useFile>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                        <dse>${dse}</dse>
-                        <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
-                    </systemPropertyVariables>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-                    </classpathDependencyExcludes>
-                    <properties>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>false
-                            </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
-                        </property>
-                        <property>
-                            <!-- Don't skip tests after a @Before method throws a SkipException -->
-                            <name>configfailurepolicy</name>
-                            <value>continue</value>
-                        </property>
-                    </properties>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <groups>${test.groups}</groups>
-                    <useFile>false</useFile>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                        <dse>${dse}</dse>
-                        <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
-                    </systemPropertyVariables>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-                    </classpathDependencyExcludes>
-                    <properties>
-                        <property>
-                            <!-- Don't skip tests after a @Before method throws a SkipException -->
-                            <name>configfailurepolicy</name>
-                            <value>continue</value>
-                        </property>
-                    </properties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <licenses>
         <license>
@@ -548,4 +1149,5 @@
             <organization>DataStax</organization>
         </developer>
     </developers>
+
 </project>

--- a/src/license/header.txt
+++ b/src/license/header.txt
@@ -1,4 +1,0 @@
-     Copyright (C) 2012-2017 DataStax Inc.
-
-     This software can be used solely with DataStax Enterprise. Please consult the license at
-     http://www.datastax.com/terms/datastax-dse-driver-license-terms


### PR DESCRIPTION
This is the DSE driver version of https://github.com/datastax/java-driver/pull/851.