### PR TITLE
JAVA-1454: Handle async Tinkerpop traversal natively with the driver

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [improvement] JAVA-1460: Add speculative execution number to ExecutionInfo.
 - [bug] JAVA-1428: Update non-required dependencies that have security vulnerabilities.
 - [bug] JAVA-1425: Upgrade to Jackson 2.8.8.
+- [improvement] JAVA-1454: Handle async Tinkerpop traversal natively with the Driver.
 
 Merged from OSS 3.x:
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <!-- more recent versions of pax-exam require JDK7+ -->
         <pax-exam.version>3.6.0</pax-exam.version>
         <url.version>2.4.0</url.version>
-        <tinkerpop.version>3.2.4</tinkerpop.version>
+        <tinkerpop.version>3.2.5</tinkerpop.version>
         <apacheds.version>2.0.0-M19</apacheds.version>
         <groovy.version>2.4.7</groovy.version>
         <testng.version>6.8.8</testng.version>


### PR DESCRIPTION
Re-opening now that Tinkerpop 3.2.5 is released.